### PR TITLE
Build against Keycloak 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-core</artifactId>
-			<version>17.0.0</version>
+			<version>19.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi</artifactId>
-			<version>17.0.0</version>
+			<version>19.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -53,8 +53,23 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi-private</artifactId>
-			<version>17.0.0</version>
+			<version>19.0.0</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-model-legacy</artifactId>
+			<version>19.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-model-legacy-private</artifactId>
+			<version>19.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-model-legacy-services</artifactId>
+			<version>19.0.0</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Update to keycloak 19:
- Move deprecated API calls to LegacyDatastoreProvider, same as upstream keycloak.
- Add legacy keycloak session modules (org.keycloak:keycloak-model-legacy-*)