### PR TITLE
bugfix: getUserByUsername args incorrect

### DIFF
--- a/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
+++ b/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
@@ -254,7 +254,7 @@ ImportedUserValidation
 		if (scimuser.getTotalResults() > 0) {
 			logger.info("User found by username!");
 			if (((LegacyDatastoreProvider) session.getProvider(DatastoreProvider.class)).userLocalStorage().getUserByUsername(realm, search) == null) {
-				UserModel user = getUserByUsername(scim.getUserName(scimuser), realm);
+				UserModel user = getUserByUsername(realm, scim.getUserName(scimuser));
 				users.add(user);
 			} else {
 				logger.info("User exists!");


### PR DESCRIPTION
The args to the `getUserByUsername` call in `performSearch` are inverted. The realm should be first, and then the username.

This PR fixes that.