### PR TITLE
Proper initialization of HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+
+		<keycloak.version>21.1.2</keycloak.version>
 	</properties>
 
 	<dependencies>
@@ -27,12 +29,12 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-core</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -53,23 +55,23 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi-private</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-model-legacy</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-model-legacy-private</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-model-legacy-services</artifactId>
-			<version>21.1.2</version>
+			<version>${keycloak.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.keycloak</groupId>
-			<artifactId>keycloak-connections-http-client</artifactId>
-			<version>1.8.1.Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi-private</artifactId>
 			<version>${keycloak.version}</version>
 			<scope>provided</scope>

--- a/src/main/java/keycloak/scim_user_spi/SCIMUserModelDelegate.java
+++ b/src/main/java/keycloak/scim_user_spi/SCIMUserModelDelegate.java
@@ -17,17 +17,19 @@ public class SCIMUserModelDelegate extends UserModelDelegate {
 
 	private ComponentModel model;
 
-	public SCIMUserModelDelegate(UserModel delegate, ComponentModel model) {
+	private final Scim scim;
+
+	public SCIMUserModelDelegate(Scim scim, UserModel delegate, ComponentModel model) {
 		super(delegate);
 		this.model = model;
+		this.scim = scim;
 	}
 
 	@Override
 	public void setAttribute(String attr, List<String> values) {
-		Scim scim = new Scim(model);
 		HttpStatus httpStatus;
 
-		SimpleHttp.Response resp = scim.updateUser(this.getUsername(), attr, values);
+		SimpleHttp.Response resp = this.scim.updateUser(scim, this.getUsername(), attr, values);
 		try {
 			if (resp.getStatus() != HttpStatus.SC_OK &&
 					resp.getStatus() != HttpStatus.SC_NO_CONTENT) {

--- a/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
+++ b/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
@@ -104,7 +104,6 @@ ImportedUserValidation
 	}
 
 	protected UserModel createUserInKeycloak(RealmModel realm, String username) {
-		Scim scim = this.scim;
 		((LegacyDatastoreProvider) session.getProvider(DatastoreProvider.class)).groupStorageManager().getGroupsCountByNameContaining(realm, username);
 
 		SCIMUser scimuser = scim.getUserByUsername(username);
@@ -130,7 +129,7 @@ ImportedUserValidation
 		}
 
 		logger.infov("Creating SCIM user {0} in keycloak", username);
-		return new SCIMUserModelDelegate(user, model);
+		return new SCIMUserModelDelegate(scim, user, model);
 	}
 
 	@Override
@@ -191,7 +190,7 @@ ImportedUserValidation
 			local.setEmail(email);
 		}
 
-		return new SCIMUserModelDelegate(local, model);
+		return new SCIMUserModelDelegate(this.scim, local, model);
 	}
 
 	// UserRegistrationProvider methods

--- a/src/main/java/keycloak/scim_user_spi/cloned/ClonedHttpClientBuilder.java
+++ b/src/main/java/keycloak/scim_user_spi/cloned/ClonedHttpClientBuilder.java
@@ -1,0 +1,341 @@
+package keycloak.scim_user_spi.cloned;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.BrowserCompatHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContexts;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.NoConnectionReuseStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+import org.keycloak.connections.httpclient.ProxyMappings;
+import org.keycloak.connections.httpclient.ProxyMappingsAwareRoutePlanner;
+
+/**
+ * Abstraction for creating HttpClients. Allows SSL configuration.
+ * 
+ * Cloned from org.keycloak.connections.httpclient.HttpClientBuilder
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+class ClonedHttpClientBuilder {
+
+    public enum HostnameVerificationPolicy {
+        /**
+         * Hostname verification is not done on the server's certificate
+         */
+        ANY,
+        /**
+         * Allows wildcards in subdomain names i.e. *.foo.com
+         */
+        WILDCARD,
+        /**
+         * CN must match hostname connecting to
+         */
+        STRICT
+    }
+
+
+    /**
+     * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+     * @version $Revision: 1 $
+     */
+    private static class PassthroughTrustManager implements X509TrustManager {
+        public void checkClientTrusted(X509Certificate[] chain,
+                                       String authType) throws CertificateException {
+        }
+
+        public void checkServerTrusted(X509Certificate[] chain,
+                                       String authType) throws CertificateException {
+        }
+
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+    }
+
+    protected KeyStore truststore;
+    protected KeyStore clientKeyStore;
+    protected String clientPrivateKeyPassword;
+    protected boolean disableTrustManager;
+    protected HostnameVerificationPolicy policy = HostnameVerificationPolicy.WILDCARD;
+    protected SSLContext sslContext;
+    protected int connectionPoolSize = 128;
+    protected int maxPooledPerRoute = 64;
+    protected long connectionTTL = -1;
+    protected boolean reuseConnections = true;
+    protected TimeUnit connectionTTLUnit = TimeUnit.MILLISECONDS;
+    protected long maxConnectionIdleTime = 900000;
+    protected TimeUnit maxConnectionIdleTimeUnit = TimeUnit.MILLISECONDS;
+    protected HostnameVerifier verifier = null;
+    protected long socketTimeout = -1;
+    protected TimeUnit socketTimeoutUnits = TimeUnit.MILLISECONDS;
+    protected long establishConnectionTimeout = -1;
+    protected TimeUnit establishConnectionTimeoutUnits = TimeUnit.MILLISECONDS;
+    protected boolean disableCookies = false;
+    protected ProxyMappings proxyMappings;
+    protected boolean expectContinueEnabled = false;
+
+    /**
+     * Socket inactivity timeout
+     *
+     * @param timeout
+     * @param unit
+     * @return
+     */
+    public ClonedHttpClientBuilder socketTimeout(long timeout, TimeUnit unit)
+    {
+        this.socketTimeout = timeout;
+        this.socketTimeoutUnits = unit;
+        return this;
+    }
+
+    /**
+     * When trying to make an initial socket connection, what is the timeout?
+     *
+     * @param timeout
+     * @param unit
+     * @return
+     */
+    public ClonedHttpClientBuilder establishConnectionTimeout(long timeout, TimeUnit unit)
+    {
+        this.establishConnectionTimeout = timeout;
+        this.establishConnectionTimeoutUnits = unit;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder connectionTTL(long ttl, TimeUnit unit) {
+        this.connectionTTL = ttl;
+        this.connectionTTLUnit = unit;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder reuseConnections(boolean reuseConnections) {
+        this.reuseConnections = reuseConnections;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder maxConnectionIdleTime(long maxConnectionIdleTime, TimeUnit unit) {
+        this.maxConnectionIdleTime = maxConnectionIdleTime;
+        this.maxConnectionIdleTimeUnit = unit;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder maxPooledPerRoute(int maxPooledPerRoute) {
+        this.maxPooledPerRoute = maxPooledPerRoute;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder connectionPoolSize(int connectionPoolSize) {
+        this.connectionPoolSize = connectionPoolSize;
+        return this;
+    }
+
+    /**
+     * Disable trust management and hostname verification. <i>NOTE</i> this is a security
+     * hole, so only set this option if you cannot or do not want to verify the identity of the
+     * host you are communicating with.
+     */
+    public ClonedHttpClientBuilder disableTrustManager() {
+        this.disableTrustManager = true;
+        return this;
+    }
+
+    /**
+     * Disable cookie management.
+     */
+    public ClonedHttpClientBuilder disableCookies(boolean disable) {
+        this.disableCookies = disable;
+        return this;
+    }
+
+    /**
+     * SSL policy used to verify hostnames
+     *
+     * @param policy
+     * @return
+     */
+    public ClonedHttpClientBuilder hostnameVerification(HostnameVerificationPolicy policy) {
+        this.policy = policy;
+        return this;
+    }
+
+
+    public ClonedHttpClientBuilder sslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder trustStore(KeyStore truststore) {
+        this.truststore = truststore;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder keyStore(KeyStore keyStore, String password) {
+        this.clientKeyStore = keyStore;
+        this.clientPrivateKeyPassword = password;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder keyStore(KeyStore keyStore, char[] password) {
+        this.clientKeyStore = keyStore;
+        this.clientPrivateKeyPassword = new String(password);
+        return this;
+    }
+
+    public ClonedHttpClientBuilder proxyMappings(ProxyMappings proxyMappings) {
+        this.proxyMappings = proxyMappings;
+        return this;
+    }
+
+    public ClonedHttpClientBuilder expectContinueEnabled(boolean expectContinueEnabled) {
+        this.expectContinueEnabled = expectContinueEnabled;
+        return this;
+    }
+
+    static class VerifierWrapper implements X509HostnameVerifier {
+        protected HostnameVerifier verifier;
+
+        VerifierWrapper(HostnameVerifier verifier) {
+            this.verifier = verifier;
+        }
+
+        @Override
+        public void verify(String host, SSLSocket ssl) throws IOException {
+            if (!verifier.verify(host, ssl.getSession())) throw new SSLException("Hostname verification failure");
+        }
+
+        @Override
+        public void verify(String host, X509Certificate cert) throws SSLException {
+            throw new SSLException("This verification path not implemented");
+        }
+
+        @Override
+        public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {
+            throw new SSLException("This verification path not implemented");
+        }
+
+        @Override
+        public boolean verify(String s, SSLSession sslSession) {
+            return verifier.verify(s, sslSession);
+        }
+    }
+
+    public CloseableHttpClient build() {
+        X509HostnameVerifier verifier = null;
+        if (this.verifier != null) verifier = new VerifierWrapper(this.verifier);
+        else {
+            switch (policy) {
+                case ANY:
+                    verifier = new AllowAllHostnameVerifier();
+                    break;
+                case WILDCARD:
+                    verifier = new BrowserCompatHostnameVerifier();
+                    break;
+                case STRICT:
+                    verifier = new StrictHostnameVerifier();
+                    break;
+            }
+        }
+        try {
+            SSLConnectionSocketFactory sslsf = null;
+            SSLContext theContext = sslContext;
+            if (disableTrustManager) {
+                theContext = SSLContext.getInstance("TLS");
+                theContext.init(null, new TrustManager[]{new PassthroughTrustManager()},
+                        new SecureRandom());
+                verifier = new AllowAllHostnameVerifier();
+                sslsf = new SSLConnectionSocketFactory(theContext, verifier);
+            } else if (theContext != null) {
+                sslsf = new SSLConnectionSocketFactory(theContext, verifier);
+            } else if (clientKeyStore != null || truststore != null) {
+                theContext = createSslContext("TLS", clientKeyStore, clientPrivateKeyPassword, truststore, null);
+                sslsf = new SSLConnectionSocketFactory(theContext, verifier);
+            } else {
+                final SSLContext tlsContext = SSLContext.getInstance("TLS");
+                tlsContext.init(null, null, null);
+                sslsf = new SSLConnectionSocketFactory(tlsContext, verifier);
+            }
+
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout((int) establishConnectionTimeout)
+                    .setSocketTimeout((int) socketTimeout)
+                    .setExpectContinueEnabled(expectContinueEnabled).build();
+
+            org.apache.http.impl.client.HttpClientBuilder builder = HttpClients.custom()
+                    .setDefaultRequestConfig(requestConfig)
+                    .setSSLSocketFactory(sslsf)
+                    .setMaxConnTotal(connectionPoolSize)
+                    .setMaxConnPerRoute(maxPooledPerRoute)
+                    .setConnectionTimeToLive(connectionTTL, connectionTTLUnit);
+
+            if (!reuseConnections) {
+                builder.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
+            }
+
+            if (proxyMappings != null && !proxyMappings.isEmpty()) {
+                builder.setRoutePlanner(new ProxyMappingsAwareRoutePlanner(proxyMappings));
+            }
+
+            if (maxConnectionIdleTime > 0) {
+                // Will start background cleaner thread
+                builder.evictIdleConnections(maxConnectionIdleTime, maxConnectionIdleTimeUnit);
+            }
+
+            if (disableCookies) builder.disableCookieManagement();
+
+            if (!reuseConnections) {
+                builder.setConnectionReuseStrategy(new NoConnectionReuseStrategy());
+            }
+
+            // The following line and respective method are the only differences to the original class
+            customizeHttpClientBuilder(builder);
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void customizeHttpClientBuilder(org.apache.http.impl.client.HttpClientBuilder builder) {
+    }
+
+    private SSLContext createSslContext(
+            final String algorithm,
+            final KeyStore keystore,
+            final String keyPassword,
+            final KeyStore truststore,
+            final SecureRandom random)
+            throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
+        return SSLContexts.custom()
+                        .useProtocol(algorithm)
+                        .setSecureRandom(random)
+                        .loadKeyMaterial(keystore, keyPassword != null ? keyPassword.toCharArray() : null)
+                        .loadTrustMaterial(truststore)
+                        .build();
+    }
+
+}

--- a/src/main/java/keycloak/scim_user_spi/cloned/ScimHttpClientBuilder.java
+++ b/src/main/java/keycloak/scim_user_spi/cloned/ScimHttpClientBuilder.java
@@ -1,0 +1,144 @@
+package keycloak.scim_user_spi.cloned;
+
+import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.common.util.EnvUtil;
+import org.keycloak.common.util.KeystoreUtil;
+import org.keycloak.connections.httpclient.ProxyMappings;
+import org.keycloak.truststore.TruststoreProvider;
+import org.keycloak.models.KeycloakSession;
+import static org.keycloak.utils.StringUtil.isBlank;
+
+// This class is based on org.keycloak.connections.httpclient.DefaultHttpClientFactory
+// to respect Keycloak settings for truststore, proxy, etc.
+
+public class ScimHttpClientBuilder {
+
+    private static final Logger logger = Logger.getLogger(ScimHttpClientBuilder.class);
+
+    private static final String configScope = "keycloak.connectionsHttpClient.default.";
+    
+    private static final String HTTPS_PROXY = "https_proxy";
+    private static final String HTTP_PROXY = "http_proxy";
+    private static final String NO_PROXY = "no_proxy";
+
+    private static boolean getBooleanConfigWithSysPropFallback(Config.Scope config, String key, boolean defaultValue) {
+        Boolean value = config.getBoolean(key);
+        if (value == null) {
+            String s = System.getProperty(configScope + key);
+            if (s != null) {
+                return Boolean.parseBoolean(s);
+            }
+        }
+        return value != null ? value : defaultValue;
+    }
+    
+    private static String getEnvVarValue(String name) {
+        String value = System.getenv(name.toLowerCase());
+        if (isBlank(value)) {
+            value = System.getenv(name.toUpperCase());
+        }
+        return value;
+    }
+
+
+    public static CloseableHttpClient createHttpClient(KeycloakSession session, CookieStore cookieStore) throws RuntimeException {
+        Config.Scope config = Config.scope("connectionsHttpClient", "default");
+
+        long socketTimeout = config.getLong("socket-timeout-millis", 5000L);
+        long establishConnectionTimeout = config.getLong("establish-connection-timeout-millis", -1L);
+        int maxPooledPerRoute = config.getInt("max-pooled-per-route", 64);
+        int connectionPoolSize = config.getInt("connection-pool-size", 128);
+        long connectionTTL = config.getLong("connection-ttl-millis", -1L);
+        boolean reuseConnections = config.getBoolean("reuse-connections", true);
+        long maxConnectionIdleTime = config.getLong("max-connection-idle-time-millis", 900000L);
+        String clientKeystore = config.get("client-keystore");
+        String clientKeystorePassword = config.get("client-keystore-password");
+        String clientPrivateKeyPassword = config.get("client-key-password");
+        boolean disableTrustManager = config.getBoolean("disable-trust-manager", false);
+        
+        boolean expectContinueEnabled = getBooleanConfigWithSysPropFallback(config, "expect-continue-enabled", false);
+        boolean resuseConnections = getBooleanConfigWithSysPropFallback(config, "reuse-connections", true);
+        
+        // optionally configure proxy mappings
+        // direct SPI config (e.g. via standalone.xml) takes precedence over env vars
+        // lower case env vars take precedence over upper case env vars
+        ProxyMappings proxyMappings = ProxyMappings.valueOf(config.getArray("proxy-mappings"));
+        if (proxyMappings == null || proxyMappings.isEmpty()) {
+            logger.debug("Trying to use proxy mapping from env vars");
+            String httpProxy = getEnvVarValue(HTTPS_PROXY);
+            if (isBlank(httpProxy)) {
+                httpProxy = getEnvVarValue(HTTP_PROXY);
+            }
+            String noProxy = getEnvVarValue(NO_PROXY);
+            
+            logger.debugf("httpProxy: %s, noProxy: %s", httpProxy, noProxy);
+            proxyMappings = ProxyMappings.withFixedProxyMapping(httpProxy, noProxy);
+        }
+        
+        // The following declaration is different from original by overriding the customizeHttpClientBuilder method
+        ClonedHttpClientBuilder builder = new ClonedHttpClientBuilder() {
+            @Override
+            protected void customizeHttpClientBuilder(org.apache.http.impl.client.HttpClientBuilder builder) {
+                builder
+				  .setDefaultCookieStore(cookieStore)
+				  .setDefaultRequestConfig(RequestConfig.custom()
+				    .setRedirectsEnabled(false)
+				    .setCookieSpec(CookieSpecs.STANDARD)
+				    .build()
+				  );
+            }
+        };
+        
+        builder.socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
+          .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)
+          .maxPooledPerRoute(maxPooledPerRoute)
+          .connectionPoolSize(connectionPoolSize)
+          .reuseConnections(reuseConnections)
+          .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
+          .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
+          .disableCookies(false)    // This intentionally does not respect disableCookies settings in Keycloak
+          .proxyMappings(proxyMappings)
+          .expectContinueEnabled(expectContinueEnabled)
+          .reuseConnections(resuseConnections);
+        
+        TruststoreProvider truststoreProvider = session.getProvider(TruststoreProvider.class);
+        boolean disableTruststoreProvider = truststoreProvider == null || truststoreProvider.getTruststore() == null;
+        
+        if (disableTruststoreProvider) {
+            logger.warn("TruststoreProvider is disabled");
+        } else {
+            builder.hostnameVerification(ClonedHttpClientBuilder.HostnameVerificationPolicy.valueOf(truststoreProvider.getPolicy().name()));
+            try {
+                builder.trustStore(truststoreProvider.getTruststore());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load truststore", e);
+            }
+        }
+        
+        if (disableTrustManager) {
+            logger.warn("TrustManager is disabled");
+            builder.disableTrustManager();
+        }
+        
+        if (clientKeystore != null) {
+            clientKeystore = EnvUtil.replace(clientKeystore);
+            try {
+                KeyStore clientCertKeystore = KeystoreUtil.loadKeyStore(clientKeystore, clientKeystorePassword);
+                builder.keyStore(clientCertKeystore, clientPrivateKeyPassword);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load keystore", e);
+            }
+        }
+        
+        return builder.build();
+    }
+
+}


### PR DESCRIPTION
This PR consists of two commits:

pom.xml cleanup:
- simplification of keycloak version management
- there was extra keycloak-connections-http-client dependency

HttpClient creation
- Taken two classes from Keycloak code base and updated slightly to serve Scim plugin purpose (see comments inside the two classes)
- Replaced HttpClient initialization accordingly
- Reduced number of places where a fresh `Scim` instance is created
