### PR TITLE
Delete intg when keycloak plugin is removed

### DIFF
--- a/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProviderFactory.java
+++ b/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProviderFactory.java
@@ -136,12 +136,6 @@ public class SCIMUserStorageProviderFactory implements UserStorageProviderFactor
 				.helpText("OPTIONAL. Full DN of the LDAP tree where your users are,"
 						+ " e.g. cn=users,dc=ipa,dc=test")
 				.add()
-				/* Remove existing integration domain option */
-				.property().name("delintgdomain")
-				.type(ProviderConfigProperty.BOOLEAN_TYPE)
-				.label("Remove existing integration domain")
-				.helpText("Option to remove existing integration domain before executing the enrollment to a new integration domain")
-				.add()
 				.build();
 	}
 
@@ -166,13 +160,8 @@ public class SCIMUserStorageProviderFactory implements UserStorageProviderFactor
 			throw new ComponentValidationException("Cannot connect to provided URL!");
 		}
 
-		Boolean del_set = Boolean.valueOf(config.getConfig().getFirst("delintgdomain"));
 		Boolean add_set = Boolean.valueOf(config.getConfig().getFirst("addintgdomain"));
 
-		if (del_set) {
-			Boolean result = scim.domainsRemove();
-			logger.infov("Delete intgDomains Result is {0}", result);
-		}
 		if (add_set) {
 			Boolean result = scim.domainsRequest();
 			logger.infov("Add intgDomains Result is {0}", result);
@@ -182,6 +171,15 @@ public class SCIMUserStorageProviderFactory implements UserStorageProviderFactor
 	@Override
 	public String getId() {
 		return PROVIDER_NAME;
+	}
+
+	@Override
+	public void preRemove(KeycloakSession session, RealmModel realm, ComponentModel config) {
+		logger.info("PreRemove");
+		Scim scim = new Scim(config, this.httpClient, this.cookieStore);
+
+		Boolean result = scim.domainsRemove();
+		logger.infov("Delete intgDomains Result is {0}", result);
 	}
 
 	@Override


### PR DESCRIPTION
No longer support the DELETE before add boolean option in the plugin configuration.