### PR TITLE
Remove realm from username in getUserByUsername

### DIFF
--- a/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
+++ b/src/main/java/keycloak/scim_user_spi/SCIMUserStorageProvider.java
@@ -99,6 +99,13 @@ ImportedUserValidation
 
 	@Override
 	public UserModel getUserByUsername(RealmModel realm, String username) {
+        /* Remove @realm, this is needed as GSSAPI auth users reach here
+         * as user@realm */
+        int idx = username.indexOf("@");
+        if (idx != -1) {
+            username = username.substring(0 , idx);
+        }
+
 		UserModel user = UserStoragePrivateUtil.userLocalStorage(session).getUserByUsername(realm,  username);
 		if (user != null) {
 			logger.info("User already exists in keycloak");


### PR DESCRIPTION
Needed as GSSAPI auth users automatically have username format 'user@realm' which would not be handled well as a username on the backend (IPA specifically)