### PR TITLE
DONOTMERGE: WIP - Check if domain was created properly

### DIFF
--- a/src/main/java/keycloak/scim_user_spi/Scim.java
+++ b/src/main/java/keycloak/scim_user_spi/Scim.java
@@ -167,6 +167,23 @@ public class Scim {
 		}
 	}
 
+	public boolean domainsCreated() {
+		SimpleHttp.Response response = null;
+		com.fasterxml.jackson.databind.JsonNode result;
+
+		/* Currently only a single domain is supported */
+		String domainurl = "domain/1";
+
+		try {
+			response = clientRequest(domainurl, "GET", null);
+			logger.infov("Response status is {0}", response.getStatus());
+			return true;
+		} catch (Exception e) {
+			logger.errorv("Failed to check if integration domain exists: {0}", e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
 	public boolean domainsRemove() {
 		SimpleHttp.Response response = null;
 		com.fasterxml.jackson.databind.JsonNode result;

--- a/src/main/java/keycloak/scim_user_spi/checkDomainCreated.java
+++ b/src/main/java/keycloak/scim_user_spi/checkDomainCreated.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package keycloak.scim_user_spi;
+
+import org.jboss.logging.Logger;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.timer.TimerProvider;
+import org.keycloak.timer.ScheduledTask;
+import keycloak.scim_user_spi.SCIMUserStorageProvider;
+
+
+/**
+ * @author <a href="mailto:jstephen@redhat.com">Justin Stephenson</a>
+ * @version $Revision: 1 $
+ */
+
+public class checkDomainCreated implements ScheduledTask {
+    private static final Logger logger = Logger.getLogger(checkDomainCreated.class);
+
+    private final Scim scim;
+    private final ComponentModel config;
+    private final RealmModel realm;
+
+    public checkDomainCreated(Scim scim, ComponentModel config, RealmModel realm) {
+        this.scim = scim;
+        this.config = config;
+        this.realm = realm;
+    }
+
+    public void run(KeycloakSession session) {
+        Boolean created = scim.domainsCreated();
+        logger.infov("Intgdomain check created result is {0}", created);
+        if (created) {
+            String cenabled = null;
+            logger.infov("Setting enabled to true");
+            config.getConfig().putSingle("enabled", Boolean.toString(true));
+            cenabled = config.getConfig().getFirst("enabled");
+            realm.updateComponent(config);
+            logger.infov("Enabled value is now {0}", cenabled);
+        } else {
+            logger.errorv("Unexpected response when checking domain creation");
+        }
+    }
+}
+


### PR DESCRIPTION
This implementation does not work yet.

Executing `config.getConfig().putSingle("enabled", Boolean.toString(true));` inside the keycloak ScheduledTask `run` method does not reflect in the runtime user storage configuration
~~~
[root@keycloak scim-keycloak-user-storage-spi]# /opt/keycloak/bin/kcadm.sh get components -q type=org.keycloak.storage.UserStorageProvider
[ {
  "id" : "5ddc1cf4-3376-4773-9cd1-f7cc60046175",
  "name" : "scimipa",
  "providerId" : "scim",
   ...
    "enabled" : [ "false" ],
~~~

If I try adding `realm.updateComponent(config);` inside the `run` method of `checkDomainCreated.java` then the following error occurs

```
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]: 2024-10-24 18:20:10,472 ERROR [org.keycloak.services.scheduled.ScheduledTaskRunner] (Timer-0) Failed to run scheduled task checkDomainCreated: org.keycloak.models.ModelException: Database operation failed
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.connections.jpa.PersistenceExceptionConverter.convert(PersistenceExceptionConverter.java:109)                                                                         
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.connections.jpa.PersistenceExceptionConverter.invoke(PersistenceExceptionConverter.java:68)                                                                           
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at jdk.proxy2/jdk.proxy2.$Proxy65.find(Unknown Source)                                                                                                                                
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.models.jpa.RealmAdapter.getComponentEntity(RealmAdapter.java:2302)                                                                                                    
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.models.jpa.RealmAdapter.updateComponent(RealmAdapter.java:2207)                                                                                                       
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at keycloak.scim_user_spi.checkDomainCreated.run(checkDomainCreated.java:56)                                         
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.services.scheduled.ScheduledTaskRunner.runTask(ScheduledTaskRunner.java:72)                    
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.services.scheduled.ScheduledTaskRunner.lambda$run$0(ScheduledTaskRunner.java:59)               
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.models.utils.KeycloakModelUtils.lambda$runJobInTransaction$1(KeycloakModelUtils.java:263)                                                      
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransactionWithResult(KeycloakModelUtils.java:386)                             
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.models.utils.KeycloakModelUtils.runJobInTransaction(KeycloakModelUtils.java:262)                            
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.services.scheduled.ScheduledTaskRunner.run(ScheduledTaskRunner.java:53)                                                
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.timer.basic.BasicTimerProvider$1.run(BasicTimerProvider.java:53)                                                       
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at java.base/java.util.TimerThread.mainLoop(Timer.java:566)                                                                                                                           
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at java.base/java.util.TimerThread.run(Timer.java:516)                                                                                                                                
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]: Caused by: java.lang.IllegalStateException: Session/EntityManager is closed                                                                                                                   
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.hibernate.internal.AbstractSharedSessionContract.checkOpen(AbstractSharedSessionContract.java:475)                            
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.hibernate.engine.spi.SharedSessionContractImplementor.checkOpen(SharedSessionContractImplementor.java:187)                                                                     
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.hibernate.internal.SessionImpl.find(SessionImpl.java:2415)                                                                                                                     
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.hibernate.internal.SessionImpl.find(SessionImpl.java:2400)                                                                            
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)                          
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at java.base/java.lang.reflect.Method.invoke(Method.java:580)                                                                                                                         
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         at org.keycloak.connections.jpa.PersistenceExceptionConverter.invoke(PersistenceExceptionConverter.java:66)                                                                           
Oct 24 18:20:10 keycloak.ipa.test kc.sh[31979]:         ... 13 more       
```

Also, if I add `SCIMUserStorageProvider prov = session.getProvider(SCIMUserStorageProvider.class);` inside the `run` method of `checkDomainCreated` class then I see that `prov` is NULL.